### PR TITLE
SATySFi のバージョンを 0.0.5 に固定

### DIFF
--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-IMAGE=amutake/satysfi:0.0.5-slim
+IMAGE=amutake/satysfi:0.0.5-59-g32f2525-slim
 
 docker run --rm -v "$(pwd):/satysfi" "${IMAGE}" satysfi $@

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-IMAGE=amutake/satysfi:nightly
+IMAGE=amutake/satysfi:0.0.5-slim
 
 docker run --rm -v "$(pwd):/satysfi" "${IMAGE}" satysfi $@


### PR DESCRIPTION
nightly だとそれぞれの手元にある satysfi のリビジョンが食い違うかもしれないのでバージョンを固定します。

なお現在の main ブランチ (nightly タグ利用) の GitHub Actions の生成物と 0.0.5 のタグを指定したときの生成物について [diff-pdf](https://github.com/vslavik/diff-pdf) で diff を取ってみると差分はありませんでした。

(https://github.com/shinchoku-tairiku/book08/issues/14#issuecomment-751459584 のはこれが原因なんじゃないかと思っています)